### PR TITLE
Updated rubygems URL, so fetching gems from there works

### DIFF
--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -59,7 +59,7 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          ruby_gems_url = 'http://production.cf.rubygems.org'
+          ruby_gems_url = 'https://api.rubygems.org'
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
           GemStore.create(IncomingGem.new(StringIO.new(content)))

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,3 +1,3 @@
 module Geminabox
-  VERSION = '0.12.4' unless defined? VERSION
+  VERSION = '0.12.5' unless defined? VERSION
 end


### PR DESCRIPTION
I discovered that the upstream fetching of gems from rubygems.org didn't work.

Log from my geminabox docker container:

``` json
{"log":"2016-02-09 08:36:45 - HTTPClient::BadResponseError - unexpected response: #\u003cHTTP::Message::Headers:0x007f33987793e0 @http_version=\"1.1\", @body_size=0, @chunked=false, @request_method=\"GET\", @request_uri=#\u003cURI::HTTP http://production.cf.rubygems.org/gems/geminabox-release-0.2.0.gem\u003e, @request_query=nil, @request_absolute_uri=nil, @status_code=404, @reason_phrase=\"Not Found\", @body_type=nil, @body_charset=nil, @body_date=nil, @body_encoding=#\u003cEncoding:ASCII-8BIT\u003e, @is_request=false, @header_item=[[\"Content-Type\", \"application/xml\"], [\"Transfer-Encoding\", \"chunked\"], [\"Connection\", \"keep-alive\"], [\"Date\", \"Tue, 09 Feb 2016 08:36:44 GMT\"], [\"Server\", \"AmazonS3\"], [\"X-Cache\", \"Error from cloudfront\"], [\"Via\", \"1.1 ea963443919f86a2bd9914edfe9c1e5f.cloudfront.net (CloudFront)\"], [\"X-Amz-Cf-Id\", \"5HM0r8FtSiMI_hm9zDroq-__ZHOZ9En0WQL-B4cKGaBdo-mRDhjcMg==\"]], @dumped=false\u003e:\n","stream":"stderr","time":"2016-02-09T08:36:45.276660421Z"}
{"log":"\u0009/geminabox_server/vendor/bundle/ruby/2.3.0/gems/httpclient-2.7.1/lib/httpclient.rb:1123:in `success_content'\n","stream":"stderr","time":"2016-02-09T08:36:45.276714648Z"}
{"log":"\u0009/geminabox_server/vendor/bundle/ruby/2.3.0/gems/httpclient-2.7.1/lib/httpclient.rb:651:in `get_content'\n","stream":"stderr","time":"2016-02-09T08:36:45.276731345Z"}
{"log":"\u0009/geminabox_server/vendor/bundle/ruby/2.3.0/gems/geminabox-0.12.4/lib/geminabox/http_adapter/http_client_adapter.rb:12:in `get_content'\n","stream":"stderr","time":"2016-02-09T08:36:45.276736017Z"}
{"log":"\u0009/geminabox_server/vendor/bundle/ruby/2.3.0/gems/geminabox-0.12.4/lib/geminabox/proxy/hostess.rb:64:in `get_from_rubygems_if_not_local'\n","stream":"stderr","time":"2016-02-09T08:36:45.276739571Z"}
{"log":"\u0009/geminabox_server/vendor/bundle/ruby/2.3.0/gems/geminabox-0.12.4/lib/geminabox/proxy/hostess.rb:52:in `block in \u003cclass:Hostess\u003e'\n","stream":"stderr","time":"2016-02-09T08:36:45.27674307Z"}
```

So http://production.cf.rubygems.org doesn't get new gems. Running gem install in verbose mode:

``` text
gem install geminabox-release -v '0.2.0' --verbose
HEAD https://api.rubygems.org/api/v1/dependencies
200 OK
GET https://api.rubygems.org/api/v1/dependencies?gems=geminabox-release
200 OK
GET https://api.rubygems.org/quick/Marshal.4.8/geminabox-release-0.2.0.gemspec.rz
302 Moved Temporarily
GET https://rubygems.global.ssl.fastly.net/quick/Marshal.4.8/geminabox-release-0.2.0.gemspec.rz
200 OK
Downloading gem geminabox-release-0.2.0.gem
GET https://api.rubygems.org/gems/geminabox-release-0.2.0.gem
302 Moved Temporarily
GET https://rubygems.global.ssl.fastly.net/gems/geminabox-release-0.2.0.gem
Fetching: geminabox-release-0.2.0.gem (100%)
200 OK
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/.gitignore
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/Gemfile
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/LICENSE
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/README.md
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/Rakefile
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/geminabox-release.gemspec
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/lib/geminabox-release.rb
/Users/hilli/.rvm/gems/ruby-2.1.5/gems/geminabox-release-0.2.0/lib/geminabox-release/version.rb
Successfully installed geminabox-release-0.2.0
Parsing documentation for geminabox-release-0.2.0
Parsing sources...
100% [ 2/ 2]  lib/geminabox-release/version.rb
Installing ri documentation for geminabox-release-0.2.0
Done installing documentation for geminabox-release after 0 seconds
1 gem installed
```

`https://api.rubygems.org` seems to be where to get gems from. Therefore this PR.
